### PR TITLE
use glob after scratch to uninstall scratch2 too

### DIFF
--- a/remove-bloat.sh
+++ b/remove-bloat.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Remove bloatware (Wolfram Engine, Libre Office, Minecraft Pi, sonic-pi dillo gpicview penguinspuzzle oracle-java8-jdk openjdk-7-jre oracle-java7-jdk openjdk-8-jre)
-sudo apt-get remove --purge wolfram-engine libreoffice* scratch minecraft-pi sonic-pi dillo gpicview penguinspuzzle oracle-java8-jdk openjdk-7-jre oracle-java7-jdk openjdk-8-jre -y
+sudo apt-get remove --purge wolfram-engine libreoffice* scratch* minecraft-pi sonic-pi dillo gpicview oracle-java8-jdk openjdk-7-jre oracle-java7-jdk openjdk-8-jre -y
 
 # Autoremove
 sudo apt-get autoremove -y


### PR DESCRIPTION
remove `penguinspuzzle` because it doesn't exist in the default sources anymore and makes the script fail then